### PR TITLE
add vunit example

### DIFF
--- a/Examples/Boards_VUnit.vhdl
+++ b/Examples/Boards_VUnit.vhdl
@@ -1,0 +1,31 @@
+library vunit_lib;
+context vunit_lib.vunit_context;
+
+use	work.json.all;
+
+entity tb_boards is
+  generic (
+    runner_cfg : string;
+    tb_path    : string;
+    filename   : string
+  );
+end entity;
+
+architecture tb of tb_boards is
+  constant JSONContent : T_JSON := jsonLoadFile(tb_path & filename);
+begin
+  main: process
+  begin
+    test_runner_setup(runner, runner_cfg);
+    while test_suite loop
+      if run("test") then
+        info(tb_path&filename);
+        info("KC705/FPGADevice: " & jsonGetString(JSONContent, "KC705/FPGADevice"));
+        info("KC705/IIC/0/Devices/1/Type: " & jsonGetString(JSONContent, "KC705/IIC/0/Devices/1/Type"));
+        info("DE4/Ethernet/2/PHY_ManagementInterface: " & jsonGetString(JSONContent, "DE4/Ethernet/2/PHY_ManagementInterface"));
+      end if;
+    end loop;
+    test_runner_cleanup(runner);
+    wait;
+  end process;
+end architecture;

--- a/VUnit/run.py
+++ b/VUnit/run.py
@@ -1,0 +1,14 @@
+from os.path import join, dirname
+from vunit import VUnit
+
+root = dirname(__file__)
+
+vu = VUnit.from_argv()
+
+lib = vu.add_library("lib")
+lib.add_source_files(join(root, "../vhdl/JSON.pkg.vhdl"))
+lib.add_source_files(join(root, "../Examples/Boards_VUnit.vhdl"))
+
+vu.set_generic("filename","../Data/Boards2.json")
+
+vu.main()

--- a/VUnit/run.sh
+++ b/VUnit/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+cd $(dirname $0)
+
+$(command -v winpty) docker run --rm -it \
+  -v /$(realpath $(pwd)/..)://work \
+  -w //work \
+  ghdl/ext:vunit-master bash -c "cd ./VUnit && VUNIT_SIMULATOR=ghdl python3 run.py -v"


### PR DESCRIPTION
This PR adds a testbench where VUnit and JSON-for-VHDL are used, and the corresponding `run.py` file.

Instead of the config package, top level generics are used to pass the project path and the name of the JSON file to be read.

The main purpose of this PR is to show how similar the VHDL APIs of VUnit's [Complex top-level generics](https://vunit.github.io/posts/2017_06_03_enable_your_simulator_to_handle_complex_top_level_generics/post.html) and JSON-for-VHDL are.

File `run.sh` is not required for user that have all the dependencies locally installed. But it allows any user with docker to run the test using the latest GHDL and VUnit, which might be useful in CI environments.